### PR TITLE
Fixed issue #2 by manually adding missing edges

### DIFF
--- a/src/stations.ts
+++ b/src/stations.ts
@@ -96,6 +96,14 @@ function initGraph() {
   const cityLoop = ['Flinders Street', 'Southern Cross', 'Flagstaff','Melbourne Central','Parliament'].map(s=>s.toLowerCase())
   cityLoop.forEach((station,i) => addEdge(station, cityLoop[(i+1) % (cityLoop.length)]))
 
+  //Add hacks for missing links where there are alternate routes not included in the main algorithm.
+  try {
+    addEdge('flinders street', 'richmond')
+    addEdge('flinders street', 'jolimont-mcg') 
+    addEdge('southern cross', 'north melbourne') 
+  } catch(e){
+  }
+
   window.n = stations.map(station => station.properties.name)
   for (const line of lines) {
     const lineStations = stationsForLine(line)


### PR DESCRIPTION
I added the misssing edges to the graph. It now correctly calculates that it is the same distance from Parliament to Jolimont as it is from Flinders Street to Jolimont.

![Screen Shot 2023-09-20 at 9 14 22 pm](https://github.com/stevage/trainle/assets/29908924/f1558c8d-a7c3-47fb-841e-506a8edfd875)
