### PR TITLE
Fix time calculation for privacy-focused browsers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -370,9 +370,7 @@ export default {
     },
     daysSinceStart() {
       const midnightOfToday = new Date();
-      midnightOfToday.setHours(0, 0, 0, 0);
       const midnightOfStart = new Date("2023-09-19");
-      midnightOfStart.setHours(0, 0, 0, 0);
 
       const diff = midnightOfToday.getTime() - midnightOfStart.getTime();
       return Math.floor(diff / (1000 * 60 * 60 * 24)) + 1;


### PR DESCRIPTION
You're doing `Math.floor()` anyway so setting the hours to 0 just makes the time inconsistent for browsers that spoof their timezones.

Test browsers: 
```
Firefox | LibreWolf
-------------------
Chrome  | Brave
```
Before:
![before](https://github.com/stevage/trainle/assets/37175276/032e8459-ffba-4344-9f21-8a091863ec0e)

After:
![after](https://github.com/stevage/trainle/assets/37175276/ed114e08-f540-4f9c-bc4b-4b073c810af0)
