### PR TITLE
Fixed bug caused by daylight savings

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -369,12 +369,13 @@ export default {
       return !this.win && !this.fail;
     },
     daysSinceStart() {
-      const midnightOfToday = new Date();
-      midnightOfToday.setHours(0, 0, 0, 0);
+      // 6am rather than midnight to solve issues with daylight savings
+      const sixAmOfToday = new Date();
+      sixAmOfToday.setHours(6, 0, 0, 0);
       const midnightOfStart = new Date("2023-09-19");
       midnightOfStart.setHours(0, 0, 0, 0);
 
-      const diff = midnightOfToday.getTime() - midnightOfStart.getTime();
+      const diff = sixAmOfToday.getTime() - midnightOfStart.getTime();
       return Math.floor(diff / (1000 * 60 * 60 * 24)) + 1;
     },
     shareText() {


### PR DESCRIPTION
The error was in `daysSinceStart()`.
It had the code 
`const midnightOfToday = new Date();
      midnightOfToday.setHours(0, 0, 0, 0);`
However because daylight savings moved clocks forward, getting the difference between it and midnight of Trainle's first day essentially became the difference between 11pm the previous day and Trainle's first day's midnight.
So I've just changed midnight to 6am:
`const sixAmOfToday = new Date();
      sixAmOfToday.setHours(6, 0, 0, 0);`
Tested it on the first 15 days of October as well as a few older dates and it seems to work correctly. :) 