### PR TITLE
Make unlimited play more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Trainle
 
 A guessing game about Melbourne's train network.
+
+Play daily at [trainle.fun](https://trainle.fun)!
+
+Play unlimited at [trainle.fun](https://trainle.fun/?unlimited)

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A guessing game about Melbourne's train network.
 
 Play daily at [trainle.fun](https://trainle.fun)!
 
-Play unlimited at [trainle.fun](https://trainle.fun/?unlimited)
+Play unlimited at [trainle.fun](https://trainle.fun/?unlimited)!

--- a/src/App.vue
+++ b/src/App.vue
@@ -71,8 +71,8 @@ v-app
         Map( :guesses="guesses.map(g=>g.station)" :target="target")
 
       #game-over
-      a(v-if"not isUnlimited() && (fail || win)" href="https://trainle.fun/?unlimited") Play Unlimited?
       v-btn#restart(v-if="isUnlimited() && (fail || win)" type="submit" @click="restart") Play again
+      v-btn.my-4.mx-1.bg-white(v-if="!isUnlimited() && (fail || win)" href="/?unlimited") Play Unlimited?
     div(style="height:80px")
     v-bottom-navigation
       v-footer

--- a/src/App.vue
+++ b/src/App.vue
@@ -71,6 +71,7 @@ v-app
         Map( :guesses="guesses.map(g=>g.station)" :target="target")
 
       #game-over
+      a(v-if"not isUnlimited() && (fail || win)" href="https://trainle.fun/?unlimited") Play Unlimited?
       v-btn#restart(v-if="isUnlimited() && (fail || win)" type="submit" @click="restart") Play again
     div(style="height:80px")
     v-bottom-navigation


### PR DESCRIPTION
I discovered this game and thirsted for more after completing the daily puzzle. To my surprise, I found an unlimited play option already implemented in the codebase.

This pull request is to advertise the unlimited play option through a link in the README and a button on the game over screen.

My apologies if that is not how the option is intended to be accessed, it was the simplest method I could find to activate it when I dug through the codebase.
