### PR TITLE
Extra aesthetics for Game 1000

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -212,7 +212,7 @@ export default {
           guesses: this.guesses.map((g) => g.station),
         },
       });
-      showConfetti();
+      showConfetti({ extraCelebration: this.isSpecialGameNumber() });
     },
 
     getGameNumber() {
@@ -402,8 +402,13 @@ export default {
   watch: {},
 };
 
-function showConfetti() {
-  var defaults = {
+/**
+ * Shower the screen in confetti.
+ *
+ * @param {boolean} [opts.extraCelebration=false] Add extra party emojis to the confetti.
+ */
+function showConfetti({ extraCelebration = false } = {}) {
+  const defaults = {
     spread: 360,
     ticks: 100,
     gravity: 0.5,
@@ -421,6 +426,10 @@ function showConfetti() {
     useWorker: true,
   };
 
+  const hundredEmoji = confetti.shapeFromText({ text: "💯" });
+  const partyPopperEmoji = confetti.shapeFromText({ text: "🎉" });
+  const partyFaceEmoji = confetti.shapeFromText({ text: "🥳" });
+
   function shoot({ ...options } = {}) {
     confetti({
       ...defaults,
@@ -437,12 +446,28 @@ function showConfetti() {
       scalar: 0.75,
       shapes: ["circle"],
     });
+
+    if (extraCelebration) {
+      confetti({
+        ...defaults,
+        ...options,
+        particleCount: 50,
+        scalar: 2,
+        flat: true,
+        shapes: [hundredEmoji, partyFaceEmoji, partyPopperEmoji],
+      });
+    }
   }
 
   setTimeout(shoot, 0);
   setTimeout(shoot, 200);
   setTimeout(shoot, 400, { startVelocity: 20 });
   setTimeout(shoot, 600, { startVelocity: 30 });
+  if (extraCelebration) {
+    setTimeout(shoot, 800, { startVelocity: 20 });
+    setTimeout(shoot, 1100, { startVelocity: 20 });
+    setTimeout(shoot, 1400, { startVelocity: 20 });
+  }
 }
 
 window.track = ({ id, parameters }) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -219,7 +219,7 @@ export default {
       if (window.location.search.match(/game=\d+/)) {
         const gameNumber = +window.location.search.match(/game=(\d+)/)[1];
         console.log(gameNumber);
-        if (gameNumber <= this.daysSinceStart || gameNumber > 1000) {
+        if (gameNumber <= this.daysSinceStart) {
           return gameNumber;
         }
       } else if (this.isUnlimited()) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,10 +11,14 @@ v-app
   v-container.px-2.px-sm-4.px-md-6
     //- .pa3.flex.flex-column(style="font-family:sans-serif; height:100vh; ")
     div(style="flex-grow:1")
-      h1.text-h4.text-lg-h2.text-center 🚂 Trainle
-        span(v-if="isUnlimited()")  unlimited
-        span(v-else)  \#{{ gameNumber }}
-        span 🚂
+      h1.text-h4.text-lg-h2.text-center
+        | 🚂 Trainle 
+        span(v-if="isUnlimited()")  Unlimited
+        span(
+          v-else
+          :class="{ specialGameNumber: isSpecialGameNumber() }"
+        ) \#{{ gameNumber }}
+        span  🚂
       v-sheet.my-5
         .text-body-1 Try to guess today's mystery station on Melbourne's metro train network.
         .text-body-1.mt-4 Each guess reveals how many stations to the target, and the distance as the crow flies.
@@ -225,6 +229,9 @@ export default {
     },
     isUnlimited() {
       return !!window.location.search.match(/unlimited/);
+    },
+    isSpecialGameNumber() {
+      return this.getGameNumber() % 1000 === 0;
     },
     testRandom() {
       const stations = {};
@@ -472,6 +479,30 @@ window.track = ({ id, parameters }) => {
 };
 </script>
 <style>
+.specialGameNumber {
+  display: inline-block;
+  background: linear-gradient(
+    90deg,
+    #ff0000,
+    #ff9900,
+    #ffee00,
+    #33cc33,
+    #3399ff,
+    #9933ff,
+    #ff0000
+  );
+  background-size: 200% auto;
+  color: transparent;
+  -webkit-background-clip: text;
+  background-clip: text;
+  animation: rainbow-shift 4s linear infinite;
+}
+
+@keyframes rainbow-shift {
+  to {
+    background-position: 200% center;
+  }
+}
 #hintmap .mapbox-ctrl-attrib-inner {
   opacity: 0.01;
 }


### PR DESCRIPTION
@stevage - I thought it might be nice to have a little something extra for Trainle's 1000th game tomorrow :D

## Changes
- Every 1000th game, the game number is rainbow 
- Every 1000th game, upon winning the game, the confetti will include extra emojis and last longer (💯, 🎉, 🥳)
- Users can no longer play any game they like after game 1000 by passing it as a URL query string (not sure if you want this - just thought it might be relevant since we'll be past game 1000 now)

## AI Use
The CSS for the rainbow game number is from ChatGPT. 

## Screenshots
<img width="388" height="405" alt="Screenshot 2026-06-13 at 3 44 43 pm" src="https://github.com/user-attachments/assets/5f1b3032-6cb1-4855-9739-3d4111bf8327" />
<img width="386" height="755" alt="Screenshot 2026-06-13 at 4 01 09 pm" src="https://github.com/user-attachments/assets/4f8a4cac-b351-407f-97c6-f2bb9fb11725" />

